### PR TITLE
Fix scripts, further typescriptification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 wiki
 gen
 build
+xpi
 *~
 *.swp
 *.debug

--- a/content/endpoint-manager.ts
+++ b/content/endpoint-manager.ts
@@ -104,20 +104,13 @@ function validatePostData(args: { [key: string]: any },
 }
 
 /**
- * returns the path of the attachment, downloading it if it doesn't exist
- * @param item
+ * Returns the path of the attachment, downloading it if it doesn't exist
  */
-async function getAttachmentPath(item): Promise<string> {
+async function getAttachmentPath(item: any): Promise<string> {
 	let filepath = item.getFilePath() as string;
 	if (!filepath || OS.File.exists(filepath)) {
-		try {
-			await Zotero.Sync.Runner.downloadFile(item);
-			filepath = item.getFilePath() as string;
-		}
-		catch (e) {
-			alert(e.message);
-			return '';
-		}
+		await Zotero.Sync.Runner.downloadFile(item);
+		filepath = item.getFilePath() as string;
 	}
 	return filepath;
 }

--- a/content/endpoint-manager.ts
+++ b/content/endpoint-manager.ts
@@ -140,7 +140,7 @@ interface SelectionResponse {
  * Returns information on the current selection in Zotero.
  */
 function getSelection(_: object): SelectionResponse {
-	const selectedItems = ZoteroPane.getSelectedItems();
+	let selectedItems = ZoteroPane.getSelectedItems();
 	const collection = ZoteroPane.getSelectedCollection() || null;
 	const childItems = collection && selectedItems.length === 0 ? collection.getChildItems() : [];
 	let libraryID = null;
@@ -148,6 +148,13 @@ function getSelection(_: object): SelectionResponse {
 	if (selectedItems.length) {
 		libraryID = selectedItems[0].library.libraryID;
 		groupID = selectedItems[0].library.groupID;
+		selectedItems = selectedItems.map(item => {
+			const data = item.toJSON();
+			if (item.isFileAttachment()) {
+				data.filepath = item.getFilePath();
+			}
+			return data as ZoteroItem;
+		});
 	}
 	else if (collection) {
 		libraryID = collection.library.libraryID;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Provides an HTTP server endpoint for interacting with Zotero",
   "scripts": {
-    "lint": "eslint . --ext .ts --cache --cache-location .eslintcache/",
+    "lint": "eslint . --ext .ts --fix --cache --cache-location .eslintcache/",
     "prebuild": "npm run lint",
     "build": "tsc --noEmit && node esbuild.js",
     "postbuild": "zotero-plugin-zipup build zotero-api-endpoint",


### PR DESCRIPTION
This factors out the request-response management from the endpoint methods so they only take input and return output, returning the requests and catching of errors is done in `addEndpoint`. This makes typing input and output easier. 